### PR TITLE
Fix carousel cleanup

### DIFF
--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect);
 
     return () => {
+      api?.off("reInit", onSelect);
       api?.off("select", onSelect);
     };
   }, [api, onSelect]);


### PR DESCRIPTION
## Summary
- clean up `reInit` event listener when unmounting carousel

## Testing
- `pnpm lint` *(fails: `next` not found)*